### PR TITLE
Fixed the median error issue.

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -127,8 +127,8 @@ function fillSheetById(countryIds, sheet)
     middleIndex -= playerLevelCount[i];
     i++
   }
-  i++ // index starts from 0
   sheet.getRange(7,6).setValue("Median: " + i);
+  i++ // index starts from 0
 
   sheet.getRange(8,6).setValue("Min: " + minLvl);
   sheet.getRange(9,6).setValue("Max: " + maxLvl);


### PR DESCRIPTION
The original median issue could occur in a case like 1, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 20, where the calculated median comes out as 15. This differs by 1 from the value returned by the built-in Sheet function MEDIAN(), and that’s how I found the key error. Simply swapping two lines of code can perfectly solve the problem.

But… I haven’t reviewed your original design logic very thoroughly, so there may still be errors in extreme cases.
If you’re open to it, the settings could directly use the built-in Sheet function MEDIAN() to generate the result, for example:

```js
sheet.getRange(7, 6).setValue(`="Median: " & MEDIAN(B3:B)`);
```

<img width="534" height="217" alt="image" src="https://github.com/user-attachments/assets/1b7691f7-dedf-484a-b0e3-04b7f7d2c00d" />

Looks good, right? But this is an additional option that might break your established design logic (maybe you prefer not to have any formulas in the report). That’s why I didn’t include it in the commit. Whether to keep it or not is up to you :D